### PR TITLE
Moji.pm: Single quotes turned an intended tab to \ t

### DIFF
--- a/lib/Lingua/JA/Moji.pm
+++ b/lib/Lingua/JA/Moji.pm
@@ -1378,7 +1378,7 @@ sub kanji2bracketed
 
 sub InKana
 {
-    return <<'END';
+    return <<"END";
 +utf8::Katakana
 +utf8::InKatakana
 +utf8::InHiragana


### PR DESCRIPTION
A tab character was meant here; instead the two character sequence
backslash-t was generated.  The solution I adopted was to make this a
double-quoted context., but there are certainly other ways.

This commit is the result of my investigation of
https://rt.perl.org/Ticket/Display.html?id=133942

Changes in 5.29 caused this illegal sequence to be caught.  I do not
know what this compiled to previously.  It may have worked as intended,
or it may have compiled into something bogus.